### PR TITLE
Support libs with shaded deps (xtdb-core)

### DIFF
--- a/src/jibbit/core.clj
+++ b/src/jibbit/core.clj
@@ -54,10 +54,12 @@
                       :docker-path (docker-path working-dir working-dir-path)})
                    ;; lib spec with a jar file
                    :else
-                   {:dir? false
-                    :path (get-path path)
-                    :from-working-dir (str "lib/" (.getName f))
-                    :docker-path (docker-path working-dir "lib" (.getName f))})))))))
+                   (let [working-dir-file (str (some-> lib-name namespace (str "__")) (name lib-name) "_" (.getName f))
+                         working-dir-path (str "lib" File/separator working-dir-file)]
+                     {:dir? false
+                      :path (get-path path)
+                      :from-working-dir working-dir-path
+                      :docker-path (docker-path working-dir working-dir-path)}))))))))
 
 (defn manifest-class-path
   "just the libs (not the source or resource paths) relative to the WORKDIR"


### PR DESCRIPTION
This adds additional specificity to lib jar names in the image
to avoid collisions that can occur when the same lib is on the
classpath, but with different maven coords, causing a
last-write-wins scenario.

The specific case this addresses is when the maven coord of shaded lib
only differs by group ID from the un-shaded lib, such as the
[clojars-mirrors](https://github.com/juxt/clojars-mirrors) libraries
that are used by [xtdb](https://github.com/xtdb/xtdb).

Adding the lib's namespace to the jar filenames inside the image
means the jar for `com.taoensso/nippy` doesn't overwrite the jar for
`pro.juxt.clojars-mirrors.com.taoensso/nippy`.

Details
-------

Currently (5e9c360), I am unable to build a working image for a project which
depends on `com.taoensso/nippy {:mvn/version "3.1.1"}` and
`com.xtdb/xtdb-core {:mvn/version "1.20.0"}`, which depends on
`pro.juxt.clojars-mirrors.com.taoensso/nippy {:mvn/version "3.1.1"}`.

When `jibblet.core/build` executed, I can see that both jars exist on
the classpath of basis from the debug output:
```
jib:INFO                /home/logan/.m2/repository/com/taoensso/nippy/3.1.1/nippy
-3.1.1.jar
..                      ...
jib:INFO                /home/logan/.m2/repository/pro/juxt/clojars-mirrors/com/t
aoensso/nippy/3.1.1/nippy-3.1.1.jar
```

But running the image results in a `FileNotFoundException`
"Could not locate ...nippy... on classpath." exception from clojure.lang.Compiler.

I can confirm only one of those jars made it into the image:

```sh-session
$ tar --to-command='tar -ztf -' -xf app.tar --wildcards --no-anchored '*.tar.gz' | grep nippy
home/app/lib/nippy-3.1.1.jar
```

After the changes in this commit, the built image works and look like:

```sh-session
$ tar --to-command='tar -ztf -' -xf app.tar --wildcards --no-anchored '*.tar.gz' | grep nippy
home/app/lib/com.taoensso__nippy_nippy-3.1.1.jar
home/app/lib/pro.juxt.clojars-mirrors.com.taoensso__nippy_nippy-3.1.1.jar
```

The rationale for adding `(namespace lib-name)` to the name, instead of
`(hash path)` technique, was a conjecture that it would promote (more) consist
builds across different machines. This is unconfirmed and open to
feedback on the new name format.