### PR TITLE
Add exposed-ports to mirror https://docs.docker.com/engine/reference/builder/#expose (and set creationTime)

### DIFF
--- a/src/jibbit/core.clj
+++ b/src/jibbit/core.clj
@@ -217,6 +217,7 @@
      (.addLabel "org.opencontainers.image.source" git-url)
      (.addLabel "com.atomist.containers.image.build" "clj -Tjib build")
      (.setWorkingDirectory (docker-path working-dir))
+     (.setCreationTime (java.time.Instant/now))
      (.setFormat (if (= :oci (:image-format target-image)) ImageFormat/OCI ImageFormat/Docker) )
      (as-> c
          (doseq [[k v] (seq env-vars)]

--- a/src/jibbit/util.clj
+++ b/src/jibbit/util.clj
@@ -1,5 +1,7 @@
 (ns jibbit.util
-  (:require [clojure.string :as str]))
+  (:require [clojure.edn]
+            [clojure.string :as str]
+            [clojure.spec.alpha :as s]))
 
 (declare subst-env-var)
 
@@ -16,3 +18,25 @@
 (defn subst-env-var [lookup s [p v]]
   (str/replace s p (or (lookup v) (throw (ex-info "no lookup" {:value v})))))
 
+(s/def ::port pos-int?)
+(s/def ::protocol #{:tcp :udp})
+(s/def ::parsed-docker-port
+  (s/keys :req-un [::port ::protocol]))
+
+(defn- parse-docker-port-s
+  [s]
+  (let [[port protocol] (clojure.string/split s #"/")]
+    {:port     (clojure.edn/read-string port)
+     :protocol (or (keyword protocol) :tcp)}))
+
+(defn parse-docker-port
+  "Parses port/protocol as per https://docs.docker.com/engine/reference/builder/#expose"
+  [pp]
+  (let [parsed (condp apply [pp]
+                 pos-int? {:port pp :protocol :tcp}
+                 string? (parse-docker-port-s pp)
+                 (throw (ex-info "Expect <port> or <port>/<protocol>. Port only can be a number. See https://docs.docker.com/engine/reference/builder/#expose" {:pp pp})))]
+    (when-not
+      (s/valid? ::parsed-docker-port parsed)
+      (throw (ex-info (s/explain-str ::parsed-docker-port parsed) {:pp pp})))
+    parsed))

--- a/test/jibbit/util_t.clj
+++ b/test/jibbit/util_t.clj
@@ -1,6 +1,6 @@
 (ns jibbit.util-t
   (:require [clojure.test :as t]
-            [jibbit.util :refer [env-subst]]))
+            [jibbit.util :refer [env-subst parse-docker-port]]))
 
 (t/deftest env-subst-tests
   (t/is (= "gcr.io/personalsdm/service" (env-subst "gcr.io/personalsdm/service" (constantly nil))))
@@ -12,3 +12,12 @@
   (t/is (= nil (env-subst nil (constantly nil))))
   (t/is (= "" (env-subst "" (constantly nil))))
   (t/is (thrown? Throwable (env-subst "gcr.io/$PROJECT_ID/service" (constantly nil)))))
+
+(t/deftest parse-docker-port-tests
+  (t/is (= {:port 80 :protocol :tcp} (parse-docker-port 80)))
+  (t/is (= {:port 80 :protocol :tcp} (parse-docker-port "80")))
+  (t/is (= {:port 80 :protocol :tcp} (parse-docker-port "80/tcp")))
+  (t/is (= {:port 53 :protocol :udp} (parse-docker-port "53/udp")))
+  (t/is (thrown? Throwable (parse-docker-port nil)))
+  (t/is (thrown? Throwable (parse-docker-port "")))
+  (t/is (thrown? Throwable (parse-docker-port "81/icmp"))))


### PR DESCRIPTION
A seq of either numbers or strings are accepted.

If strings, they follow the Docker format.

The config key is this:

```
{:exposed-ports [80 "53/tcp"]}
```