### PR TITLE
Bump libs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,15 +1,14 @@
 {:paths ["src"]
  :tools/usage {:ns-default jibbit.core
                :ns-aliases {jib jibbit.core}}
- :deps {io.github.clojure/tools.build 
-        {:git/url "https://github.com/clojure/tools.build" :git/tag "v0.8.1" :git/sha "7d40500863818c6f9a6e077b18db305d02149384" :exclusions [com.google.guava/guava]}
-        com.google.cloud.tools/jib-core {:mvn/version "0.20.0"}
-        com.cognitect.aws/api {:mvn/version "0.8.539"}
-        com.cognitect.aws/ecr {:mvn/version "814.2.1053.0"}}
+ :deps {io.github.clojure/tools.build {:mvn/version "0.9.4" :exclusions [com.google.guava/guava]}
+        com.google.cloud.tools/jib-core {:mvn/version "0.23.0"}
+        com.cognitect.aws/api {:mvn/version "0.8.656"}
+        com.cognitect.aws/ecr {:mvn/version "821.2.1107.0"}}
  :aliases {:test 
            {:extra-deps {com.magnars/test-with-files {:mvn/version "2021-02-17"}
                          org.apache.commons/commons-vfs2 {:mvn/version "2.9.0"}
-                         io.github.cognitect-labs/test-runner {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+                         io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
             :extra-paths ["test"]
             :main-opts ["-m" "cognitect.test-runner"]
             :exec-fn cognitect.test-runner.api/test

--- a/src/jibbit/core.clj
+++ b/src/jibbit/core.clj
@@ -3,7 +3,6 @@
             [clojure.string :as str]
             [clojure.java.io :as io]
             [clojure.edn :as edn]
-            [clojure.pprint :refer [pprint]]
             [jibbit.build :refer [configure-image get-path]]
             [jibbit.util :as util]
             [jibbit.report :as report])
@@ -135,12 +134,12 @@
   [{:keys [basis aot jar-name main working-dir]}]
   (into ["java" "-Dclojure.main.report=stderr" "-Dfile.encoding=UTF-8"]
         (concat
-         (-> basis :classpath-args :jvm-opts)
+         (-> basis :argmap :jvm-opts)
          (if aot
            ["-jar" jar-name]
            (concat
             ["-cp" (container-cp basis working-dir) "clojure.main"]
-            (if-let [main-opts (-> basis :classpath-args :main-opts)]
+            (if-let [main-opts (-> basis :argmap :main-opts)]
               main-opts
               ["-m" (pr-str main)]))))))
 
@@ -307,7 +306,7 @@
                      :working-dir working-dir
                      :basis basis}
                     (dissoc params :config))]
-    (when-not (or (-> basis :classpath-args :main-opts) (:main jib-config))
+    (when-not (or (-> basis :argmap :main-opts) (:main jib-config))
       (throw (ex-info "config must specify either :main or an alias with :main-opts" {})))
     jib-config))
 


### PR DESCRIPTION
1. Update dependencies (`jib-core` first of all) to fix broken support of ["distroless" container images](https://github.com/GoogleContainerTools/distroless).
    > Since March 2023, Distroless images use oci manifests, if you see errors referencing application/vnd.oci.image.manifest.v1+json or application/vnd.oci.image.index.v1+json, update your container tooling (docker, jib, etc) to latest.

3. Apply a change suggested at #19.