### PR TITLE
Add entry-point option to Jibbit config

### DIFF
--- a/src/jibbit/util.clj
+++ b/src/jibbit/util.clj
@@ -40,3 +40,9 @@
       (s/valid? ::parsed-docker-port parsed)
       (throw (ex-info (s/explain-str ::parsed-docker-port parsed) {:pp pp})))
     parsed))
+
+(defn load-var
+  [entry-point]
+  (when-let [sym (some-> entry-point symbol)]
+    (some-> sym namespace symbol require)
+    (resolve sym)))


### PR DESCRIPTION
Closes #23 
---

## changes

- add a `load-var` util function to resolve a given symbol
- rename `core/entry-point` to `core/default-entry-point` for clarity
- allows a user to provide `:entry-point` symbol in the jib config with his own implementation of `entry-point`.

## Example of use case

For example, a project might want to have some env var passed down and a specify the shell like so:
```clojure
(ns jibbit
  (:require [jibbit.core :as jibbit]))

(defn my-entry-point
  [{:keys [basis main working-dir]}]
  (->> (concat
        ["java ${JAVA_OPTS} -Dclojure.main.report=stderr -Dfile.encoding=UTF-8"]
        (concat
         ["-cp" (jibbit/container-cp basis working-dir) "clojure.main"]
         (if-let [main-opts (-> basis :argmap :main-opts)]
           main-opts
           ["-m" (pr-str main)])))
       (interpose " ")
       (apply str)
       (conj ["/bin/sh" "-c"])))
```

Then, this implementation can be specified in the `jib.edn` for instance:

```clojure
{:main         my.app.core
 :user         "root"
 :group        "root"
 :base-image   {:image-name "openjdk:11-slim-buster"
                :type       :registry}
 :target-image {:image-name "props-reco/test"
                :type       :docker
                :tag "test"}
 :entry-point jibbit/my.entry-point}
```